### PR TITLE
Point at new Metarouter package

### DIFF
--- a/packages/core/RNAnalytics.podspec
+++ b/packages/core/RNAnalytics.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{m,h}'
   s.static_framework    = true
 
-  s.dependency          'AstronomerAnalytics'
+  s.dependency          'MetarouterAnalytics', '~> 3.8.0-beta.3'
   s.dependency          'React'
 end

--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -7,7 +7,7 @@
 
 #import "RNAnalytics.h"
 
-#import <AstronomerAnalytics/SEGAnalytics.h>
+#import <MetarouterAnalytics/SEGAnalytics.h>
 #import <React/RCTBridge.h>
 
 static NSMutableSet* RNAnalyticsIntegrations = nil;


### PR DESCRIPTION
Currently `https://api.astronomer.io/v1/batch` is returning a cert error. I figure we should probably be using the new MetarouterAnalytics package anyway (which points at the new metarouter.io endpoints)

If this isn't true, I would appreciate a path forward to getting this package working again. 

